### PR TITLE
Bln 6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BLN
 Type: Package
 Title: Calculate the Soil Quality Assessment Score using the Dutch BLN framework
-Version: 0.5.2
+Version: 0.6.0
 Authors@R: c(
     person("Gerard", "Ros", email = "gerard.ros@nmi-agro.nl", role = c("aut","cre")),
     person("Sven", "Verweij", email = "sven.verweij@nmi-agro.nl", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BLN
 Type: Package
 Title: Calculate the Soil Quality Assessment Score using the Dutch BLN framework
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person("Gerard", "Ros", email = "gerard.ros@nmi-agro.nl", role = c("aut","cre")),
     person("Sven", "Verweij", email = "sven.verweij@nmi-agro.nl", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# BLN 0.6.0 2025-02-18
+
+## Changed
+* the argument `outputtype` in `bln_field_optimiser` has new arguments: scores, indicators, bottlenecks, rotation or all, #BLN-6
+* `bln_field_optimiser` can give the score per ESD and aggregated BLN function for each of the requested crop rotations (option scores)
+* `bln_field_optimiser` can give the score per indicators for each of the requested crop rotations (option indicators)
+* `bln_field_optimiser` can give the bottleneck per ESD or aggregated BLN function (option bottlenecks)
+* `bln_field_optimiser` can give the best crop rotation per ESD or aggregated BLN function (option rotation)
+
+## Updated
+* test for `bln_field_optimiser` given the update in function argumentation
+
 # BLN 0.5.1 2025-01-14
 
 ## Changed

--- a/R/bln_field_optimiser.R
+++ b/R/bln_field_optimiser.R
@@ -83,6 +83,7 @@ bln_field_optimiser<-function(ID, B_LU_BRP,B_SC_WENR,B_GWL_CLASS,B_SOILTYPE_AGR,
 
   # add visial bindings
   scen = soiltype = . = b_aer_cbs = fieldid = b_lu_brp = B_CT_PSW_MAX = variable = indicator = s_bln_total = esd = NULL
+  bln_score = bln_indicator = NULL
 
   # load internal table with crop rotation scenarios
   bln_rot_scen <- BLN::bln_scen_croprotation

--- a/man/bln_field_optimiser.Rd
+++ b/man/bln_field_optimiser.Rd
@@ -58,7 +58,7 @@ bln_field_optimiser(
   LSW = NULL,
   i_clim_rothc = NA_real_,
   A_SOM_LOI_MLMAX = NA_real_,
-  foptim = list(scenarios = NULL, b_lu_brp = NULL, outputtype = "cr_best_bln", mc = TRUE,
+  foptim = list(scenarios = NULL, b_lu_brp = NULL, outputtype = "rotation", mc = TRUE,
     runrothc = TRUE)
 )
 }
@@ -176,8 +176,12 @@ This function estimates what crop rotation plan is mosts suited for the current 
 }
 \details{
 the foptim is a list with parameters affecting the selection of best crop rotation plans.
-the parameter outputtype gives the user the possibility to select specific outcomes: cr_nbottlenecks (nr of bottlenecks per scenario), cr_esd (BLN score per ESD),
-cr_best_bln (best rotation for BLN total), cr_best_per_esd (best rotation per ESD), cr_esd_obi (OBI score) or all
+the parameter outputtype gives the user the possibility to select specific outcomes:
+scores (gives all scores per rotation)
+indicators (gives the indicator values per rotation)
+bottlenecks (gives the number of bottlenecks per rotation)
+rotation (gives the best rotation for BLN total, per ESD and OBI)
+all (all output options)
 The parameter b_lu_brp allows the user to send an user defined crop rotation using BRP codes. This will replace the default scenarios as long as the parameter scenarios is NULL.
 The parameter scenarios allows the user to select only specific crop rotation scenarios from the package table `bln_scen_croprotation`
 }

--- a/tests/testthat/test-bln_field_optimiser.R
+++ b/tests/testthat/test-bln_field_optimiser.R
@@ -14,6 +14,9 @@
     # B_DRAIN = dt.farm$B_DRAIN
     # B_FERT_NORM_FR = dt.farm$B_FERT_NORM_FR
     # B_SLOPE_DEGREE = dt.farm$B_SLOPE_DEGREE
+    # B_SOMERS_BC = NA_real_
+    # B_DRAIN_SP = NA_real_
+    # B_DRAIN_WP = NA_real_
     # B_GWP = dt.farm$B_GWP
     # B_AREA_DROUGHT = dt.farm$B_AREA_DROUGHT
     # B_CT_PSW = dt.farm$B_CT_PSW
@@ -73,10 +76,12 @@
     # M_MECHWEEDS = NA
     # M_PESTICIDES_DST = NA
     # B_LSW_ID = NA_character_
+    # i_clim_rothc = NA_real_
     # LSW = NULL
     # output ='all'
+    # foptim = list(scenarios = NULL, b_lu_brp = NULL, outputtype = 'rotation',mc = TRUE,runrothc = TRUE)
 
-# unit test
+    # unit test
 test_that("bln_field works", {
 
   # select properties
@@ -138,34 +143,21 @@ test_that("bln_field works", {
                             i_clim_rothc = NA_real_,
                             B_LSW_ID = NA_character_,
                             LSW = NULL,
-                            foptim = list(scenarios = NULL, b_lu_brp = NULL, outputtype = 'all',mc = TRUE,runrothc = TRUE))
+                            foptim = list(scenarios = NULL, b_lu_brp = NULL, outputtype = 'scores',mc = TRUE,runrothc = TRUE))
 
   # test for dimensions dataset
-  expect_equal(dim(d1), expected = c(1,29), tolerance = 0.1 )
+  expect_equal(dim(d1), expected = c(1,157), tolerance = 0.1 )
 
   # test for colnames
-  cols <- c("ID","bld_arable_ext_bnc","bld_arable_int_bnc","bld_arable_prot_bnc","bld_cereals_bnc",
-            "bld_divers_bnc","bld_gld_collaboration_bnc","bld_int_bnc","bld_vegetable_ext_bnc","bld_vegetable_int_bnc",
-            "current_bnc","gld_permanent_bnc","sms_permanent_bnc","bld_arable_ext_bln_hs","bld_arable_int_bln_hs",
-            "bld_arable_prot_bln_hs","bld_cereals_bln_hs","bld_divers_bln_hs","bld_gld_collaboration_bln_hs", "bld_int_bln_hs",
-            "bld_vegetable_ext_bln_hs","bld_vegetable_int_bln_hs","current_bln_hs","gld_permanent_bln_hs","sms_permanent_bln_hs",
-            "s_bln_esd_clim_blu","s_bln_esd_nut_blu","s_bln_esd_prod_blu","s_bln_esd_water_blu")
-  expect_equal(colnames(d1), expected = cols, tolerance = 0.1 )
+  cols <- c("ID","bld_arable_int_s_esd_nut_hs","bld_arable_prot_s_esd_clim_hs",
+            "bld_int_s_bln_prod_c_hs","current_s_bln_prod_p_hs","sms_permanent_s_esd_nut_hs")
+  expect_equal(colnames(d1)[c(1,25,37,85,125,155)], expected = cols, tolerance = 0.1 )
 
   # test BLN score
-  expect_equal(d1$bld_arable_int_bln_hs, expected = c(0.66), tolerance = 0.01)
+  expect_equal(d1$bld_arable_int_s_bln_total_hs, expected = c(0.66), tolerance = 0.01)
 
   # test BLN soil quality score ESD production
-  expect_equal(d1$bld_gld_collaboration_bln_hs, expected = 0.65, tolerance = 0.01)
-
-  # test BLN soil quality score ESD water quality
-  expect_equal(d1$s_bln_esd_nut_blu, expected = 'gld_permanent', tolerance = 0.01)
-
-  # test BLN soil quality score ESD climate
-  expect_equal(d1$bld_vegetable_int_bnc, expected = 15, tolerance = 0.01)
-
-  # test BLN soil quality score ESD nutrient cycle
-  expect_equal(d1$bld_int_bln_hs, expected = .63, tolerance = 0.01)
+  expect_equal(d1$bld_gld_collaboration_s_bln_total_hs, expected = 0.65, tolerance = 0.01)
 
 
   # run BLN
@@ -221,30 +213,20 @@ test_that("bln_field works", {
                             i_clim_rothc = NA_real_,
                             B_LSW_ID = NA_character_,
                             LSW = NULL,
-                            foptim = list(scenarios = NULL, b_lu_brp = NULL, outputtype = 'cr_esd_obi',mc = TRUE,runrothc = TRUE))
+                            foptim = list(scenarios = NULL, b_lu_brp = NULL, outputtype = 'rotation',mc = TRUE,runrothc = TRUE))
 
   # test for dimensions dataset
-  expect_equal(dim(d1), expected = c(1,37), tolerance = 0.1 )
+  expect_equal(dim(d1), expected = c(1,14), tolerance = 0.1 )
 
   # test for colnames
-  cols <- c("ID",
-            "s_bln_prod_b_bld_arable_ext_obi_hs","s_bln_prod_b_bld_arable_int_obi_hs",
-            "s_bln_prod_b_bld_arable_prot_obi_hs","s_bln_prod_b_bld_cereals_obi_hs","s_bln_prod_b_bld_divers_obi_hs" ,
-            "s_bln_prod_b_bld_gld_collaboration_obi_hs", "s_bln_prod_b_bld_int_obi_hs","s_bln_prod_b_bld_vegetable_ext_obi_hs",
-            "s_bln_prod_b_bld_vegetable_int_obi_hs","s_bln_prod_b_current_obi_hs","s_bln_prod_b_gld_permanent_obi_hs" ,
-            "s_bln_prod_b_sms_permanent_obi_hs","s_bln_prod_c_bld_arable_ext_obi_hs","s_bln_prod_c_bld_arable_int_obi_hs" ,
-            "s_bln_prod_c_bld_arable_prot_obi_hs","s_bln_prod_c_bld_cereals_obi_hs","s_bln_prod_c_bld_divers_obi_hs" ,
-            "s_bln_prod_c_bld_gld_collaboration_obi_hs", "s_bln_prod_c_bld_int_obi_hs","s_bln_prod_c_bld_vegetable_ext_obi_hs",
-            "s_bln_prod_c_bld_vegetable_int_obi_hs","s_bln_prod_c_current_obi_hs","s_bln_prod_c_gld_permanent_obi_hs",
-            "s_bln_prod_c_sms_permanent_obi_hs","s_bln_prod_p_bld_arable_ext_obi_hs","s_bln_prod_p_bld_arable_int_obi_hs",
-            "s_bln_prod_p_bld_arable_prot_obi_hs","s_bln_prod_p_bld_cereals_obi_hs","s_bln_prod_p_bld_divers_obi_hs",
-            "s_bln_prod_p_bld_gld_collaboration_obi_hs", "s_bln_prod_p_bld_int_obi_hs","s_bln_prod_p_bld_vegetable_ext_obi_hs",
-            "s_bln_prod_p_bld_vegetable_int_obi_hs","s_bln_prod_p_current_obi_hs","s_bln_prod_p_gld_permanent_obi_hs",
-            "s_bln_prod_p_sms_permanent_obi_hs")
+  cols <- c("ID",  "s_bln_clim_blu","s_bln_esd_clim_blu","s_bln_esd_nut_blu",
+            "s_bln_esd_prod_blu","s_bln_esd_water_blu","s_bln_gw_quality_blu" , "s_bln_gw_quantity_blu",
+            "s_bln_nut_blu","s_bln_prod_b_blu","s_bln_prod_c_blu","s_bln_prod_p_blu",
+            "s_bln_sw_quality_blu" , "s_bln_total_blu"  )
   expect_equal(colnames(d1), expected = cols, tolerance = 0.1 )
 
   # test BLN score
-  expect_equal(d1$s_bln_prod_c_sms_permanent_obi_hs, expected = c(0.74), tolerance = 0.01)
+  expect_equal(d1$s_bln_prod_c_blu , expected = c('sms_permanent'), tolerance = 0.01)
 
 
 })


### PR DESCRIPTION
# BLN 0.6.0 2025-02-18

## Changed
* the argument `outputtype` in `bln_field_optimiser` has new arguments: scores, indicators, bottlenecks, rotation or all, #BLN-6
* `bln_field_optimiser` can give the score per ESD and aggregated BLN function for each of the requested crop rotations (option scores)
* `bln_field_optimiser` can give the score per indicators for each of the requested crop rotations (option indicators)
* `bln_field_optimiser` can give the bottleneck per ESD or aggregated BLN function (option bottlenecks)
* `bln_field_optimiser` can give the best crop rotation per ESD or aggregated BLN function (option rotation)

## Updated
* test for `bln_field_optimiser` given the update in function argumentation